### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "all",
     "require-dir"
   ],
+  "license": "MIT",
   "main": "./lib/file-manifest",
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
So it displays without an * in tools like:
https://www.npmjs.com/package/license-checker